### PR TITLE
Add exact search

### DIFF
--- a/search_service/exact_search.py
+++ b/search_service/exact_search.py
@@ -1,0 +1,48 @@
+from cgitb import text
+from typing import Any, List
+from pymongo.collection import Collection
+from database.mongodb import prod_database as db
+
+
+class ExactSearch:
+    def __init__(self, collection: Collection):
+        self.collection = collection
+
+    def search(self, text_query: str, min_score: float = 2.5) -> List["dict[str, Any]"]:
+        stage_match_text = {
+            '$search': {
+                'index': 'text',
+                'text': {
+                    'query': text_query,
+                    'path': {
+                        'wildcard': '*'
+                    }
+                }
+            }
+        }
+
+        stage_get_score = {
+            "$addFields": {
+                "text_match_score": {
+                    "$meta": "searchScore"
+                }
+            }
+        }
+
+        stage_filter_score = {
+            "$match": {
+                "text_match_score": {
+                    "$gte": min_score
+                }
+            }
+        }
+
+        _filter = [stage_match_text, stage_get_score, stage_filter_score]
+
+        cursor = self.collection.aggregate(_filter)
+        results = []
+
+        for item in cursor:
+            results.append(item)
+
+        return results

--- a/search_service/exact_search.py
+++ b/search_service/exact_search.py
@@ -8,7 +8,7 @@ class ExactSearch:
     def __init__(self, collection: Collection):
         self.collection = collection
 
-    def search(self, text_query: str, min_score: float = 2.5) -> List["dict[str, Any]"]:
+    def search(self, text_query: str, min_score: float = 3) -> List["dict[str, Any]"]:
         stage_match_text = {
             '$search': {
                 'index': 'text',


### PR DESCRIPTION
1. Added exact search by using MongoDb Atlas Search
2. Combined semantic search results + exact search results. Exact search results appear first.

Lots of database calls due to the fact that there is a one to many relationship between Articles to Restaurants and Blurbs to Articles. Might have to make a table in MongoDB that has restaurants, articles + blurbs all together so we reduce the number of DB calls if latency gets bad.